### PR TITLE
refactor: persist avatar path to MySQL with Redis TTL cache

### DIFF
--- a/api/src/main/java/com/family/diary/api/service/tencentcloud/impl/COSServiceImpl.java
+++ b/api/src/main/java/com/family/diary/api/service/tencentcloud/impl/COSServiceImpl.java
@@ -24,6 +24,7 @@ import com.family.diary.common.exceptions.BaseException;
 import com.family.diary.common.utils.common.ImageUtils;
 import com.family.diary.common.utils.redis.RedisUtil;
 import com.family.diary.domain.entity.tencentcloud.cos.COSAvatarUploadEntity;
+import com.family.diary.domain.repository.user.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.logging.log4j.util.Strings;
@@ -48,6 +49,8 @@ public class COSServiceImpl implements COSService {
 
     private final ImageUtils imageUtils;
 
+    private final UserRepository userRepository;
+
     @Override
     public String uploadAvatarToCOS(COSAvatarUploadEntity entity) throws BaseException {
         var openid = entity.getOpenId();
@@ -60,7 +63,8 @@ public class COSServiceImpl implements COSService {
             log.error("上传头像到 COS 失败，文件存储路径：{}", filePath);
             throw new BaseException(ExceptionErrorCode.COMMON_ERROR, "上传头像到 COS 失败");
         }
-        saveAvatarPathCache(openid, filePath);
+        userRepository.updateAvatarPath(openid, filePath);
+        cacheAvatarPath(openid, filePath);
         saveAvatarCache(openid, imageUrl);
         log.info("上传图片到 COS 成功，文件存储路径：{}", filePath);
         log.debug("临时访问地址：{}", imageUrl);
@@ -109,13 +113,22 @@ public class COSServiceImpl implements COSService {
         if (cachedPath != null && !cachedPath.isEmpty()) {
             return cachedPath;
         }
-        log.warn("未找到用户头像文件路径缓存，使用默认PNG格式，openid: {}", openid);
+        log.info("Redis 路径缓存未命中，查询 MySQL，openid: {}", openid);
+        var user = userRepository.findByOpenId(openid);
+        if (user != null && user.getAvatarPath() != null && !user.getAvatarPath().isEmpty()) {
+            cacheAvatarPath(openid, user.getAvatarPath());
+            return user.getAvatarPath();
+        }
+        log.warn("MySQL 中未找到用户头像文件路径，使用默认PNG格式，openid: {}", openid);
         return buildFilePathWithId(openid, COSConstants.AVATARS_DIR, ImageConstants.IMAGE_PNG_FORMAT);
     }
 
-    private void saveAvatarPathCache(String openid, String filePath) {
+    private void cacheAvatarPath(String openid, String filePath) {
         var cacheKey = getAvatarPathCacheKey(openid);
-        redisUtil.set(cacheKey, filePath);
+        var success = redisUtil.setWithExpire(cacheKey, filePath, COSConstants.AVATARS_PATH_CACHE_TTL, TimeUnit.SECONDS);
+        if (!success) {
+            log.warn("Redis 缓存头像文件路径失败，openid: {}", openid);
+        }
     }
 
     private String getAvatarPathCacheKey(String openid) {

--- a/common/src/main/java/com/family/diary/common/constants/tencentcloud/COSConstants.java
+++ b/common/src/main/java/com/family/diary/common/constants/tencentcloud/COSConstants.java
@@ -41,4 +41,9 @@ public interface COSConstants {
      * 头像文件路径缓存前缀
      */
     String AVATARS_PATH_CACHE_KEY_PREFIX = "avatar:path";
+
+    /**
+     * 头像文件路径缓存过期时间，单位为秒（24小时）
+     */
+    Long AVATARS_PATH_CACHE_TTL = 24 * 60 * 60L;
 }

--- a/domain/src/main/java/com/family/diary/domain/entity/user/UserEntity.java
+++ b/domain/src/main/java/com/family/diary/domain/entity/user/UserEntity.java
@@ -79,4 +79,9 @@ public class UserEntity extends BaseEntity {
      * 用户状态
      */
     private UserFlagStatus flag;
+
+    /**
+     * 头像文件路径
+     */
+    private String avatarPath;
 }

--- a/domain/src/main/java/com/family/diary/domain/repository/user/UserRepository.java
+++ b/domain/src/main/java/com/family/diary/domain/repository/user/UserRepository.java
@@ -47,4 +47,13 @@ public interface UserRepository {
      * @return 用户实体
      */
     UserEntity findByOpenId(String openId);
+
+    /**
+     * 更新用户头像文件路径
+     *
+     * @param openId     微信用户OpenID
+     * @param avatarPath 头像文件路径
+     * @return 更新的记录数：1成功，0失败
+     */
+    int updateAvatarPath(String openId, String avatarPath);
 }

--- a/infrastructure/src/main/java/com/family/diary/infrastructure/po/user/UserPo.java
+++ b/infrastructure/src/main/java/com/family/diary/infrastructure/po/user/UserPo.java
@@ -79,4 +79,9 @@ public class UserPo extends BasePo {
      * 用户状态
      */
     private String flag;
+
+    /**
+     * 头像文件路径
+     */
+    private String avatarPath;
 }

--- a/infrastructure/src/main/java/com/family/diary/infrastructure/repository/user/UserRepositoryImpl.java
+++ b/infrastructure/src/main/java/com/family/diary/infrastructure/repository/user/UserRepositoryImpl.java
@@ -16,6 +16,7 @@
 package com.family.diary.infrastructure.repository.user;
 
 import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+import com.baomidou.mybatisplus.core.conditions.update.LambdaUpdateWrapper;
 import com.family.diary.common.exceptions.ConflictException;
 import com.family.diary.domain.entity.user.UserEntity;
 import com.family.diary.domain.repository.user.UserRepository;
@@ -63,5 +64,13 @@ public class UserRepositoryImpl implements UserRepository {
             log.error("OpenId {} 查询到多个用户", openId);
             throw new ConflictException("OpenId重复!");
         }
+    }
+
+    @Override
+    public int updateAvatarPath(String openId, String avatarPath) {
+        var updateWrapper = new LambdaUpdateWrapper<UserPo>()
+                .eq(UserPo::getOpenId, openId)
+                .set(UserPo::getAvatarPath, avatarPath);
+        return userDAO.update(updateWrapper);
     }
 }


### PR DESCRIPTION
Avatar file path was stored permanently in Redis without TTL, treating Redis as persistent storage. Now avatar_path is persisted in the user table (MySQL) and Redis serves only as a 24h TTL cache layer with fallback: Redis → MySQL → default PNG.